### PR TITLE
Add drivers functions 

### DIFF
--- a/src/python/drivers/align_mbs_traces.py
+++ b/src/python/drivers/align_mbs_traces.py
@@ -1,0 +1,138 @@
+"""
+:module: Mt_Baker_LF_Research/src/python/drivers/align_mbs_traces.py
+:auth: Benz Poobua
+:email: spoobu@uw.edu
+:org: University of Washington
+:license: GNU GPLv3
+:purpose: This driver aligns traces relative to one another based on their cross-correlation value.
+
+"""
+
+import os, glob
+from pathlib import Path
+from obspy import Catalog
+from eqcorrscan.utils.stacking import align_traces
+
+from eqcutil.core.clusteringtribe import ClusteringTribe
+from eqcutil.util.logging import setup_terminal_logger, CriticalExitHandler
+
+# Set up logging
+Logger = setup_terminal_logger(name=__name__)
+Logger.addHandler(CriticalExitHandler(exit_code=1))
+# Get absolute path for repo root directory
+root = Path(__file__).parent.parent.parent.parent
+# Safety check that it's running from root directory
+if os.path.split(root)[-1] != 'Mt_Baker_LF_Research':
+    Logger.critical(f'root path does not appear to look like the repo root: {root}')
+else:
+    Logger.warning(f'running {__file__} from {root}')
+
+# Get path for ClusteringTribe
+processed_path = os.path.join(root,'processed_data','clusters','well_located_20km')
+ctr_file_path = os.path.join(processed_path,'hyper_parameter_trials')
+ctr_files = glob.glob(os.path.join(ctr_file_path, 'fv_mean_sl_1.0_ls_False.tgz'))
+
+# Load the ClusteringTribe
+filepath = ctr_files[0]
+ctr = ClusteringTribe().read(filepath)
+Logger.info('ClusteringTribe loaded')
+ctr2 = ctr.copy() # 155 templates
+
+# Set the ccv threshold of the alignment result
+ccv_threshold = 0.7
+
+# Initialize an empty catalog (shifted)
+all_events = []
+
+# Save path for subcatalog 
+subcat_path = os.path.join(root,'processed_data','sub_catalog')
+os.makedirs(subcat_path, exist_ok=True)
+filename = f'sub_cat_ccv_threshold_{ccv_threshold}.xml'
+subcat_filepath = os.path.join(subcat_path, filename)
+
+for group_no in ctr2.clusters.correlation_cluster.unique():
+    sub_ctr = ctr2.select_cluster(method='correlation_cluster', index=group_no)
+    if len(sub_ctr) >= 3: # the number of templates
+        trace_list = {}
+        trace_list_metadata = {}
+        for template in sub_ctr.templates:
+            for tr in template.st:
+                # if tr.id not in trace_list.keys():
+                #     trace_list.update({tr.id: [tr]})
+                #     trace_list_metadata.update({tr.id: [template.name]})
+                if tr.id not in trace_list.keys():
+                    trace_list[tr.id] = [tr]
+                    trace_list_metadata[tr.id] = [template.name]
+                else:
+                    trace_list[tr.id].append(tr)
+                    trace_list_metadata[tr.id].append(template.name)
+        keys_to_remove = [] # Prevent RuntimeError (dictionary changed size)
+        for _k, _v in trace_list.items(): # Iterate across trace lists and remove lists with fewer than 3 traces
+            if len(_v) < 3:
+                keys_to_remove.append(_k)
+            else:
+                realignment_results = align_traces(_v, shift_len=1, 
+                                                   master=False, positive=True)
+                shifts, ccvs = realignment_results  # Unpack realignment_results into two lists
+                for name, shift, ccv in zip(trace_list_metadata[_k], shifts, ccvs):
+                    if ccv >= ccv_threshold:
+                        # Get a relevant template
+                        template = sub_ctr.select(name) 
+                        # Get the template's event
+                        event = template.event 
+                        # Iterate across picks to find matching
+                        # No need to augment the waveforms in `create_mbs_tribe.py`
+                        # Access the picks attribute of the Event
+                        for pick in event.picks:
+                            if pick.waveform_id: # Ensure waveform_id exists 
+                                pick.time += shift  # Apply the shift to the pick's time
+
+    # Remove the keys (less than 3 traces)
+    for key in keys_to_remove:
+        trace_list.pop(key, None)
+        trace_list_metadata.pop(key, None)
+        
+    # Add the events from sub_ctr to all_events
+    all_events.extend([template.event for template in sub_ctr.templates])
+    # sub_cat = Catalog(events=[temp.event for temp in sub_ctr.templates])
+
+# Construct catalog after looping
+sub_cat = Catalog(events=all_events)
+
+# Save the sub catalog
+sub_cat.write(subcat_filepath, format="QUAKEML")
+
+
+
+
+
+# # Example to check if the shift is applied successfully
+# # Extract the event ID from cat (e.g., '61138827')
+# cat_event_id = cat.events[10].resource_id.id.split('/')[-1]  # Extracts '61138827'
+
+# # Find the corresponding event in sub_cat
+# found_event_in_sub_cat = None
+# for sub_cat_event in sub_cat:
+#     sub_cat_event_id = sub_cat_event.resource_id.id.split('/')[-1]  # Extract event ID from sub_cat
+    
+#     if sub_cat_event_id == cat_event_id:
+#         found_event_in_sub_cat = sub_cat_event
+#         break
+
+# if found_event_in_sub_cat:
+#     print(f"Comparing pick times for Event ID: {cat_event_id}")
+    
+#     # Print pick times from the original catalog (cat)
+#     print("\nPick times from cat (original):")
+#     for pick in cat.events[10].picks:
+#         print(f"  {pick.phase_hint} pick time: {pick.time}")
+    
+#     # Print pick times from the sub catalog (sub_cat)
+#     print("\nPick times from sub_cat (shifted):")
+#     for pick in found_event_in_sub_cat.picks:
+#         print(f"  {pick.phase_hint} pick time: {pick.time}")
+# else:
+#     print(f"No matching event found for Event ID {cat_event_id} in sub_cat.")
+
+# ctr2.select_template_traces(station='MBW*')
+# ctr[1].st.select(station='MBW')

--- a/src/python/drivers/cluster_mbs_shifted_tribe.py
+++ b/src/python/drivers/cluster_mbs_shifted_tribe.py
@@ -1,5 +1,5 @@
 """
-:module: Mt_Baker_LF_Research/src/python/drivers/cluster_mbs_tribe.py
+:module: Mt_Baker_LF_Research/src/python/drivers/cluster_mbs_shifted_tribe.py
 :auth: Benz Poobua
 :email: spoobu@uw.edu
 :org: University of Washington

--- a/src/python/drivers/cluster_mbs_shifted_tribe.py
+++ b/src/python/drivers/cluster_mbs_shifted_tribe.py
@@ -1,0 +1,149 @@
+"""
+:module: Mt_Baker_LF_Research/src/python/drivers/cluster_mbs_tribe.py
+:auth: Benz Poobua
+:email: spoobu@uw.edu
+:org: University of Washington
+:license: GNU GPLv3
+:purpose: This driver clusters templates using shifted waveform
+    cross-correlation based grouping routines provided
+    by EQcorrscan. These routines are re-packaged in the
+    `eqcutil.core.clusteringtribe.ClusteringTribe` class.
+
+    It iterates across a set of hyper-parameters that influence
+    the calculation of pairwise similarity "distance" values for
+    template pairs and saves the results of each clustering analysis
+    as a *.tgz file named with the hyper-parameter values
+
+:Hyper Parameters:
+    Fill Value (fv) - value used to pad un-paired channels between
+        templates. Short-hand name for `replace_nan_distances_with`
+
+        Currently assesses: fv = 1., 'mean'
+
+        Value Explainer
+        1 - Apply the maximum penalty to representative correlation
+            strength for each missing channel pair.
+
+            "Maximum penality - correlation strength of a missing pair is 0".
+
+        0 - Apply the minimum penalty to representative correlation
+            strength for each missing channel pair. WARNING: may tend
+            to over-emphasize the importance of correlations between
+            templates with very few matching channels.
+
+        'mean' - Fill missing values with the average pair-wise
+            maximum correlation amplitude of existing channel pairs.
+
+            "Do not penalize overall correlation strength due to missing pairs"
+            
+        'min' - Fill missing values with the existing pairs' maximum correlation
+            strength (minimum distance)
+            "Accentuate the importance of existing channel pairs'
+            correlation strength"
+
+
+        DEBUG: 'min' appears to have some bugs at the eqcorrscan distribution
+            level. 
+    
+    Shift Length (sl) - maximum correlation shift length permitted
+        for finding a correlation amplitude maximum for each channel
+        pair between templates. `shift_len`. Units of seconds
+
+        Currently assesses: sl = 1., 5., 10.
+    
+    Lockstep Shifts (ls) - alias for the opposite of `allow_individual_trace_shifts`
+        Currently assesses: ls = True, False
+        
+        Value Explainer
+            ls = True - the maximum correlation amplitude (minimum distance)
+                is calculated for a single, uniform shift of all traces in one
+                template
+            ls = False - the maximum correlation amplitude (minimum distance)
+                between two templates is calculated from the channel-wise corelation
+                amplitude maxima, which may have different shift values
+    
+
+"""
+
+import os, glob
+from pathlib import Path
+
+from eqcorrscan import Template
+
+from eqcutil.core.clusteringtribe import ClusteringTribe
+from eqcutil.util.logging import setup_terminal_logger, CriticalExitHandler
+
+# Set up logging
+Logger = setup_terminal_logger(name=__name__)
+Logger.addHandler(CriticalExitHandler(exit_code=1))
+# Get absolute path for repo root directory
+root = Path(__file__).parent.parent.parent.parent
+# Safety check that it's running from root directory
+if os.path.split(root)[-1] != 'Mt_Baker_LF_Research':
+    Logger.critical(f'root path does not appear to look like the repo root: {root}')
+else:
+    Logger.warning(f'running {__file__} from {root}')
+
+# Get path for templates
+tdir = os.path.join(root,'processed_data','shifted_templates','well_located_20km')
+# Get list of template names
+tnames = glob.glob(os.path.join(tdir,'*.tgz'))
+
+# Major parameters
+fill_values = [1, 'mean']
+shift_lens = [1., 10.]
+locksteps = [True, False]
+overwrite_protect = False
+
+save_path = os.path.join(root,'processed_data',
+                         'shifted_clusters','well_located_20km',
+                         'hyper_parameter_trials')
+
+### PROCESSING SECTION ###
+
+# Load Templates
+Logger.info(f'Constructing ClusteringTribe from {len(tnames)} saved templates')
+ctr = ClusteringTribe()
+for tfile in tnames:
+    Logger.debug(f'loading: {tfile}')
+    itemp = Template().read(tfile)
+    ctr.extend(itemp)
+Logger.info(f'{len(ctr.templates)} of {len(tnames)} loaded')
+
+for fill_value in fill_values:
+    for shift_len in shift_lens:
+        for lockstep in locksteps:
+
+            ccckwargs = {'method': 'correlation_cluster',
+                        'replace_nan_distances_with': fill_value,
+                        'shift_len': shift_len,
+                        'corr_thresh': 0.7,
+                        'allow_individual_trace_shifts': not lockstep,
+                        'show': False,
+                        'cores': 'all',
+                        'save_corrmat': False}
+
+            Logger.info(f'running fill_value {fill_value} | shift_len {shift_len} sec | lockstep shifts {lockstep}')
+
+            # dynamically generate save directory/file name
+            savename = os.path.join(save_path,
+                                    f'fv_{fill_value}_sl_{shift_len}_ls_{lockstep}')
+
+            # Overwrite Protection Clause
+            if os.path.isfile(f'{savename}.tgz'):
+                if overwrite_protect:
+                    Logger.info(f'{savename}.tgz already exists - skipping to next')
+                    continue
+                else:
+                    Logger.warning(f'overwriting existing file {savename}.tgz')
+
+            # Run Clustering
+            Logger.info(f'Running waveform-based clustering analysis on ClusteringTribe')
+            ctr.cluster(**ccckwargs)
+
+            # Save to Disk
+            Logger.info(f'Writing results to: {savename}.tgz')
+            ctr.write(savename)
+
+# Signal End
+Logger.critical('SUCCESSFULLY COMPLETED PROCESS - EXITING')

--- a/src/python/drivers/create_mbs_shifted_tribe.py
+++ b/src/python/drivers/create_mbs_shifted_tribe.py
@@ -1,5 +1,5 @@
 """
-:module: Mt_Baker_LF_Research/src/python/drivers/create_mbs_tribe.py
+:module: Mt_Baker_LF_Research/src/python/drivers/create_mbs_shifted_tribe.py
 :auth: Benz Poobua 
 :email: spoobu@uw.edu
 :org: University of Washington

--- a/src/python/drivers/create_mbs_shifted_tribe.py
+++ b/src/python/drivers/create_mbs_shifted_tribe.py
@@ -1,0 +1,132 @@
+"""
+:module: Mt_Baker_LF_Research/src/python/drivers/create_mbs_tribe.py
+:auth: Benz Poobua 
+:email: spoobu@uw.edu
+:org: University of Washington
+:license: GNU GPLv3
+:purpose: This driver creates shifted templates for a sub-catalog
+    of PNSN events near Mt. Baker that satisfy pre-defined
+    requirements for being "well-located". The shift is refered to 
+    `align_mbs_traces.py`
+"""
+
+import os, logging
+from pathlib import Path
+
+import pandas as pd
+from obspy import Catalog, read_events
+from obspy.clients.fdsn import Client
+from eqcorrscan import Template, Tribe
+
+from eqcutil.augment.catalog import apply_phase_hints, filter_picks
+from eqcutil.augment.template import rename_templates, augment_template
+from eqcutil.util.logging import setup_terminal_logger, CriticalExitHandler
+
+# Set up logging at debug level reporting
+Logger = setup_terminal_logger(__name__,level=logging.DEBUG)
+# Add a critical -> sysexit handler custom class
+Logger.addHandler(CriticalExitHandler(exit_code=1))
+
+### CONTROL PARAMETER DEFINITION SECTION ###
+
+# Define paths data sources
+# Get root directory of the repository
+root = Path(__file__).parent.parent.parent.parent
+# Safety check that it's running from root directory
+if os.path.split(root)[-1] != 'Mt_Baker_LF_Research':
+    Logger.critical(f'root path does not appear to look like the repo root: {root}')
+else:
+    Logger.warning(f'running {__file__} from {root}')
+
+# Path to shifted catalog
+subcat_path = os.path.join(root,'processed_data','sub_catalog')
+
+# Load shifted catalog
+xml_files = [f for f in os.listdir(subcat_path) if f.endswith('.xml')]
+subcat_filepath = os.path.join(subcat_path, xml_files[0])
+
+# Define waveform client
+wfclient = Client("IRIS")
+
+# Define Pick Filtering kwargs
+pfkwargs = {'phase_hints': ['P'],
+            'enforce_single_pick': 'earliest',
+            'stations': ['MBW','MBW2','SHUK',
+                         'SAXON','RPW2','PASS',
+                         'MULN','RPW2']}
+
+# Define template construction kwargs
+ckwargs = {'method': 'from_client',
+           'client_id': wfclient,
+           'lowcut': 0.5,
+           'highcut': 20.,
+           'filt_order': 4,
+           'samp_rate': 50.,
+           'prepick': 10.,
+           'length': 50.,
+           'process_len': 300.,
+           'min_snr': 3.,
+           'parallel': True,
+           'num_cores': 4, 
+           'save_progress': False
+           }
+
+# Define template augmentation kwargs
+akwargs = {'client': wfclient,
+           'padding': 120.}
+
+# Define Save Directory
+savedir = os.path.join(root, 'processed_data','shifted_templates','well_located_20km')
+
+##### PROCESSING SECTION #####
+if not os.path.exists(savedir):
+    Logger.info(f'making savedir: {savedir}')
+    os.makedirs(savedir)
+else:
+    Logger.info(f'saving to existing savedir: {savedir}')
+
+## Get event catalog
+cat = read_events(subcat_filepath)
+
+if len(cat) > 0:
+    Logger.info(f'Fetched {len(cat)} event\'s metadata from the EventBank')
+else:
+    Logger.critical(f'Failed to fetch any event metadata from the EventBank')
+
+## Apply phase hints
+Logger.info('Applying phase hints')
+cat = apply_phase_hints(cat)
+
+## Filter Catalog
+Logger.info(f'Filtering catalog picks for: {pfkwargs}')
+pfkwargs.update({'catalog': cat})
+cat = filter_picks(**pfkwargs)
+
+sta_set = dict(zip(pfkwargs['stations'], [0]*len(pfkwargs['stations'])))
+for _e in cat.events:
+    for _p in _e.picks:
+        sta_set[_p.waveform_id.station_code] += 1
+Logger.info(f'Pick counts are: {sta_set}')
+for event in cat.events:
+    icat = Catalog(events=[event])
+    ckwargs.update({'catalog': icat})
+    Logger.info(f'constructing template for: {icat[0].resource_id}')
+    try:
+        tribe = Tribe().construct(**ckwargs)
+    except:
+        Logger.warning('failed to construct template - continuing to next')
+        continue
+    # Rename templates
+    Logger.info(f'renaming templates with EVID')
+    tribe = rename_templates(tribe)
+
+    for template in tribe:
+        # Augment Templates
+        # Logger.info(f'Augmenting waveform data on {template.name}')
+        # template = augment_template(template=template, **akwargs)    
+        Logger.info(f'Saving template {tribe[0].name} to {savedir}')
+        template.write(os.path.join(savedir, f'{template.name}.tgz'))
+
+
+    
+

--- a/src/python/drivers/create_mbs_tribe.py
+++ b/src/python/drivers/create_mbs_tribe.py
@@ -163,20 +163,14 @@ for event in cat.events:
     Logger.info(f'renaming templates with EVID')
     tribe = rename_templates(tribe)
 
+
     for template in tribe:
         # Augment Templates
-        Logger.info(f'Augmenting waveform data on {template.name}')
-        template = augment_template(template=template, **akwargs)    
+        # Logger.info(f'Augmenting waveform data on {template.name}')
+        # template = augment_template(template=template, **akwargs)    
         Logger.info(f'Saving template {tribe[0].name} to {savedir}')
         template.write(os.path.join(savedir, f'{template.name}.tgz'))
 
 
-        
-
-
-# ## Iterate across events & create templates
-# for event in cat.events:
-#     Logger.info('processing event')
-# for evid, row in df_eb.iterrows():
-#     event = ebank.get_events(event_id=row.event_id)
+    
 

--- a/src/python/drivers/stack_mbs_traces.py
+++ b/src/python/drivers/stack_mbs_traces.py
@@ -1,0 +1,45 @@
+"""
+:module: Mt_Baker_LF_Research/src/python/drivers/stack_mbs_traces.py
+:auth: Benz Poobua
+:email: spoobu@uw.edu
+:org: University of Washington
+:license: GNU GPLv3
+:purpose: This driver stacks traces using shifted clusters.
+
+"""
+
+import os, glob
+from pathlib import Path
+from obspy import Stream
+from eqcorrscan.utils.stacking import linstack
+
+from eqcutil.core.clusteringtribe import ClusteringTribe
+from eqcutil.util.logging import setup_terminal_logger, CriticalExitHandler
+
+# Set up logging
+Logger = setup_terminal_logger(name=__name__)
+Logger.addHandler(CriticalExitHandler(exit_code=1))
+# Get absolute path for repo root directory
+root = Path(__file__).parent.parent.parent.parent
+# Safety check that it's running from root directory
+if os.path.split(root)[-1] != 'Mt_Baker_LF_Research':
+    Logger.critical(f'root path does not appear to look like the repo root: {root}')
+else:
+    Logger.warning(f'running {__file__} from {root}')
+
+# Get path for ClusteringTribe
+processed_path = os.path.join(root,'processed_data','shifted_clusters','well_located_20km')
+ctr_file_path = os.path.join(processed_path,'hyper_parameter_trials')
+ctr_files = glob.glob(os.path.join(ctr_file_path, 'fv_mean_sl_1.0_ls_False.tgz'))
+
+# Load the ClusteringTribe
+filepath = ctr_files[0]
+ctr = ClusteringTribe().read(filepath)
+Logger.info('ClusteringTribe loaded')
+ctr2 = ctr.copy()
+
+# Construct input
+st_list = [temp.st for temp in ctr2.templates]
+
+# Stack
+stack = linstack(st_list)


### PR DESCRIPTION
`align_mbs_traces.py`
- Refer to `align_traces()` function in EQcorrscan
- Construct ([shifts], [ccv])
- Construct shifted catalog by adding shifts to the original cat pick time
- Results saved in processed_data/sub_catalog

`create_mbs_shifted_tribe.py`
- Construct templates using newly shifted cat
- Results saved in processed_data/shifted_templates
- Obtained 128 *.tgz files
- Failed to construct templates for some stations: No data available for request (HTTP status code: 204)

`cluster_mbs_shifted_tribe.py`
- Cluster the shifted templates
- Results saved in processed_data/shifted_clusters

`stack_mbs_traces.py`
- Use derived shifted cluster to generate stack
- Stack is a Stream object (7 traces in Stream).
- Unsure of implementing the next step, I stop here.
